### PR TITLE
El escalado (proporcional o no) funciona para conjunto de cajas seleccionado (no para grupo)

### DIFF
--- a/src/Stores/Models/GroupModel.js
+++ b/src/Stores/Models/GroupModel.js
@@ -1,5 +1,7 @@
 import { types, getRoot } from 'mobx-state-tree';
 import ItemModel from './ItemModel';
+import { Point } from '../../Utils/planeTransforms.js';
+import { visuallySetItem, scaleItem } from '../../Utils/Math.js';
 
 const GroupModel = types
   .model('GroupModel', {
@@ -29,6 +31,56 @@ const GroupModel = types
       },
       setRotation(rotate) {
         self.rotate = rotate;
+      },
+      getCoordinatesfromSlide(item) {
+        // Given an item inside the group, we get the coordinates (left, top, rotate)
+        // from the slide
+        return {left: item.left + self.left,
+          top: item.top + self.top,
+          rotate: item.rotate + self.rotate, width: item.width, height: item.height};
+      },
+      getCoordinatesfromGroup(p){ 
+        return new Point(p.x - self.left, p.y - self.top);
+      },
+      setSize(width, height) {
+        self.width = width;
+        self.height = height;
+      },
+      scale(scaleFactor, scaleCenter, topLeftGroupContainer){
+        // Update the position, width and height of each children
+        self.groupedItems.map(item => {
+          // Since the top-left vertex of each item is computed with respect
+          // to the group top-left corner we change our coordinate system to
+          // the one provided by the group container to do the scale.
+          let newScaleCenter = self.getCoordinatesfromGroup(scaleCenter);
+          // let newScaleCenter = new Point(scaleCenter.x - topLeftGroupContainer.x, scaleCenter.y - topLeftGroupContainer.y);
+          // newScaleCenter.log();
+          let newItemData = scaleItem(scaleFactor, newScaleCenter, item);
+          // newItemData.left -= topLeftGroupContainer.x - self.left; 
+          // newItemData.top -= topLeftGroupContainer.y - self.top; 
+          // Since the origin of coordinates (top-left corner) is changing
+          // with the scaling, the new data of the children (top, left, width, height)
+          // is obtained multiplying the original values by the `scaleFactor`
+          newItemData.left = item.left * scaleFactor;
+          newItemData.top = item.top * scaleFactor;
+          newItemData.width = item.width * scaleFactor;
+          newItemData.height = item.height * scaleFactor;
+          newItemData.rotate = item.rotate;
+
+          // We update the position of the item in the browser. 
+          // Notice that since each item is a child of a div.group with
+          // a position:absolute attribute its coordinates are refered
+          // to the parent instead of the `slide`
+          visuallySetItem(newItemData, item);
+        });
+        // // Update the top-left cornor of the *container*
+        // let newContainerData = scaleItem(scaleFactor, scaleCenter, self);
+        // // Update the with and height of the *container*
+        // self.width = scaleFactor*self.width;
+        // self.width = newContainerData.width;
+        // self.height = newContainerData.height;
+        // self.left = newContainerData.left;
+        // self.top = newContainerData.top;
       }
     };
   });

--- a/src/Utils/Math.js
+++ b/src/Utils/Math.js
@@ -97,8 +97,8 @@ const rotarItem = (angle, center, item) => {
  * (Visually) proportionally scale `item` with respect to `center` 
  * The function does not change item properties
  * 
- * @param {Number} scaleFactor - scale transformation to apply. 
- * @param {Point} center - centor of the scale
+ * @param {Number} scaleFactor - scale factor to apply. 
+ * @param {Point} center - center of the scale
  * @param {Item} item - item to scale
  */
 const scaleItem = (scaleFactor, center, item) => {
@@ -127,7 +127,6 @@ const scaleItem = (scaleFactor, center, item) => {
   item.node.style.top = itemNewTopLeft.y + 'px'; 
   $(item.node).css({width: newWidth, height: newHeight});
   $(item.node).css('transform', 'rotate(' + item.rotate + 'deg)');
-
 };
 
 export {

--- a/src/Utils/Math.js
+++ b/src/Utils/Math.js
@@ -31,6 +31,9 @@ const getRotationDegrees = $obj => {
 const changeCoordinatesFromWindowToSlide = function(slideTopLeft, delta, point) {
   return new Point( (point.x - slideTopLeft.x)/delta, (point.y - slideTopLeft.y)/delta);
 };
+const changeCoordinatesFromSlideToWindow = function(slideTopLeft, delta, point) {
+  return new Point( delta*point.x + slideTopLeft.x, delta*point.y + slideTopLeft.y );
+};
 // Esta función se usa para pintar puntos en la pantalla y poder
 // depurar de forma correcta
 const paintPoint = (x, y) => {
@@ -134,4 +137,5 @@ export {
   paintDiv,
   getRotationDegrees,
   changeCoordinatesFromWindowToSlide,
+  changeCoordinatesFromSlideToWindow,
 };

--- a/src/Utils/Math.js
+++ b/src/Utils/Math.js
@@ -58,6 +58,21 @@ const paintDiv = (x, y, w, h) => {
   }).appendTo('#root');
 };
 
+
+/*
+ * (Visually) Set a box in the slide from new point, width, height and rotate
+ * using CSS transforms
+ *
+ * @param {Object} {left, top, width, height, rotate}
+ */
+const visuallySetItem = ({left, top, width, height, rotate}, item) => {
+  // Visually rotate item using CSS transforms
+  item.node.style.left = left + 'px'; 
+  item.node.style.top = top + 'px'; 
+  $(item.node).css({width: width, height: height});
+  $(item.node).css('transform', 'rotate(' + rotate + 'deg)');
+};
+
 /*
  * (Visually) rotate `item` an `angle` with respect a given `center`
  * The function does not change item properties.
@@ -87,10 +102,12 @@ const rotarItem = (angle, center, item) => {
   // It is the sum of the initial rotation and the new one
   const nuevaRotacion = angle + item.rotate;
 
+  let newItemData = {left: nuevaPosicion.x, top: nuevaPosicion.y, width: item.width, height: item.height, rotate: nuevaRotacion};
+
   // Visually rotate item using CSS transforms
-  item.node.style.left = nuevaPosicion.x + 'px'; 
-  item.node.style.top = nuevaPosicion.y + 'px'; 
-  $(item.node).css('transform', 'rotate(' + nuevaRotacion + 'deg)');
+  visuallySetItem(newItemData, item);
+
+  return newItemData;
 };
 
 /* 
@@ -123,11 +140,17 @@ const scaleItem = (scaleFactor, center, item) => {
   const itemNewTopLeft = translate(new Point(-newWidth/2, -newHeight/2))(itemNewCenter);
 
   // Visually rotate item using CSS transforms
-  item.node.style.left = itemNewTopLeft.x + 'px'; 
-  item.node.style.top = itemNewTopLeft.y + 'px'; 
-  $(item.node).css({width: newWidth, height: newHeight});
-  $(item.node).css('transform', 'rotate(' + item.rotate + 'deg)');
+  // item.node.style.left = itemNewTopLeft.x + 'px'; 
+  // item.node.style.top = itemNewTopLeft.y + 'px'; 
+  // $(item.node).css({width: newWidth, height: newHeight});
+  // $(item.node).css('transform', 'rotate(' + item.rotate + 'deg)');
+  
+  let newItemData = {left: itemNewTopLeft.x, top: itemNewTopLeft.y, width: newWidth, height: newHeight, rotate: item.rotate};
+  // visuallySetItem(newItemData, item);
+
+  return newItemData;
 };
+
 
 /* 
  * (Visually) non-proportionally scale `item` with respect to `center` by 
@@ -174,6 +197,7 @@ const scaleDirItem = (scaleFactor, scaleDirection, center, item) => {
 };
 
 export {
+  visuallySetItem,
   rotarItem,
   scaleItem,
   scaleDirItem,

--- a/src/Utils/ResizeItem.js
+++ b/src/Utils/ResizeItem.js
@@ -2,14 +2,14 @@ import interact from 'interactjs';
 import store from '../Store';
 import $ from 'jquery';
 import { getRotationDegrees, changeCoordinatesFromWindowToSlide, changeCoordinatesFromSlideToWindow, scaleItem, scaleDirItem } from './Math';
-import {Point, rotate, translate, scale} from './planeTransforms.js';
+import {Point, rotate, translate, scale, scaleDir} from './planeTransforms.js';
 
 var selector;
 var slide;
 var scaleCenter = new Point(0,0);     // Center of the scale transformation
 var scaleFactor = 0;                  // Scale factor to apply
 
-var clickPoint = ''; // vertex of the selector clicked by the user
+var clickedPoint = ''; // vertex of the selector clicked by the user
 
 // Direction of the mouse movement that will be consider to scale the element
 var scaleDirection = new Point(0,0);
@@ -27,12 +27,14 @@ const attachResize = () => {
         parseFloat(store.selector.node.style.left), 
         parseFloat(store.selector.node.style.top)
       );
+
       // We compute the coordinates of the selector with respect to slide
       selector = changeCoordinatesFromWindowToSlide(
         slide, 
         store.delta, 
         selectorFromWindow
       );
+
       // We add to selector its width, height, angle and diagonal length
       // with respect to the slide (store.delta scaled)
       selector.width = parseFloat(store.selector.node.style.width)/store.delta;
@@ -46,16 +48,15 @@ const attachResize = () => {
       // id del tirador: 
       // - 'nm', 'wm', 'em', 'sm' Puntos medios
       // - 'ne', 'nw', 'se', 'sw' Esquinas
-      // console.log(event.currentTarget.getAttribute('id')); 
+      clickedPoint = event.currentTarget.getAttribute('id');
 
-      clickPoint = event.currentTarget.getAttribute('id');
       // Compute the center of the scale. It is the opposite point selected
       // by the user. Observe that (selector.x, selector.y) is the top left
       // corner of the selector before selector.rotate (if any)
       // TODO: If p is the point with coordinates with respect to the slide 
       // of the point clicked by the user the following switch can be sustituted by
       // const scaleCenter = rotate(180, new Point(selector.x + selector.width/2, selector.y + selector.height/2))(p);
-      switch(clickPoint){
+      switch(clickedPoint){
         case 'nw':
           scaleCenter = new Point(
             selector.x + selector.width, 
@@ -128,8 +129,140 @@ const attachResize = () => {
       // get its coordinates in the slide
       scaleCenter = rotate(selector.rotate, new Point(selector.x + selector.width/2, selector.y + selector.height/2))(scaleCenter);
       scaleDirection = rotate(selector.rotate)(scaleDirection);
+    },
+    onmove: event => {
+      var userPull = new Point(event.dx, event.dy);
+      scaleDelta += userPull.component(scaleDirection) / store.delta;
 
+      // TODO: The transformation applied to the `selector` is exactly the same
+      // to the one applied to item. However, since `selector` and `item` do
+      // not have the same model (notice that SelectorModel and ItemModel 
+      // represents the top-left vertex by (x,y) and (left, right) respectively)
+      // we cannot use the `scaleItem` function to update the selector 
+      // position, width and height. As a consequence, we have to repeat
+      // the same inner code of `scaleItem` or `scaleDirItem` to update selector. 
+      // Moreover, selector coordinates are computed with respect to the window 
+      // and a change of coordinate is needed to correctly position it 
+      // in the slide.
 
+      // Apply the non-proportional scale if the `clickedPoint` is in the 
+      // midpoint of one of the selector sides.
+      if (clickedPoint === 'em' || clickedPoint === 'nm' || clickedPoint === 'wm' || clickedPoint === 'sm'){
+        if (clickedPoint === 'em' || clickedPoint === 'wm'){
+          scaleFactor = (selector.width + scaleDelta) / selector.width;
+        }
+        else {
+          scaleFactor = (selector.height + scaleDelta) / selector.height;
+        }
+
+        // Update selector position
+        const selectorCenter = new Point( selector.x + selector.width / 2, selector.y + selector.height / 2 );
+        const selectorTopLeft = rotate(selector.rotate, selectorCenter)(
+          selector
+        );
+        const selectorTopRight = rotate(selector.rotate, selectorCenter)(
+          new Point( selector.x + selector.width, selector.y )
+        );
+        const selectorBottomLeft = rotate(selector.rotate, selectorCenter)(
+          new Point( selector.x, selector.y + selector.height )
+        );
+
+        // The angle of the selector has not changed since scale preserves angles
+        // The new center of selector is the *transformed* center by the scale
+        const selectorNewCenter = scaleDir(scaleFactor, scaleDirection, scaleCenter)(selectorCenter);
+        const newWidth = Point.distance(
+          scaleDir(scaleFactor, scaleDirection, scaleCenter)(selectorTopLeft),
+          scaleDir(scaleFactor, scaleDirection, scaleCenter)(selectorTopRight)
+        );
+        const newHeight = Point.distance(
+          scaleDir(scaleFactor, scaleDirection, scaleCenter)(selectorTopLeft),
+          scaleDir(scaleFactor, scaleDirection, scaleCenter)(selectorBottomLeft)
+        );
+        let selectorNewTopLeft = translate(new Point(-newWidth/2, -newHeight/2))(selectorNewCenter);
+
+        // We transform coordinates from slide to window
+        selectorNewTopLeft = changeCoordinatesFromSlideToWindow(slide, store.delta, selectorNewTopLeft);
+        // Position #selector in the window. It is not necessary to `rotate`
+        // again the element since the scale does not affect the rotation of
+        // the element.
+        $('#selector').css({ left: selectorNewTopLeft.x, top: selectorNewTopLeft.y });
+
+        // Finally we *scale* the selector. We have to take into account that
+        // the coordinate system for the selector is outside the slide so
+        // we have to correct the scale factor by `store.delta`
+        $('#selector').css({width: newWidth*store.delta, height: newHeight*store.delta});
+
+        // Scale all the selected elements.
+        store.selectedItems.map(item => {
+          scaleDirItem(scaleFactor, scaleDirection, scaleCenter, item);
+        });
+
+      }
+      else{ // Apply the proportional scale
+        scaleFactor = (selector.diagonal + scaleDelta) / selector.diagonal;
+
+        // Update selector position
+        // We move the top-left vertex of the selector according with the 
+        // applied transformation
+        const selectorNewCenter = scale(scaleFactor, scaleCenter)(
+          new Point(selector.x + selector.width/2, selector.y + selector.height/2)
+        );
+        let selectorNewTopLeft = translate(new Point(-selector.width*scaleFactor/2, -selector.height*scaleFactor/2))(selectorNewCenter);
+
+        // We transform coordinates from slide to window
+        selectorNewTopLeft = changeCoordinatesFromSlideToWindow(slide, store.delta, selectorNewTopLeft);
+        // Position #selector in the window. It is not necessary to `rotate`
+        // again the element since the scale does not affect the rotation of
+        // the element.
+        $('#selector').css({ left: selectorNewTopLeft.x, top: selectorNewTopLeft.y });
+
+        // Finally we *scale* the selector. We have to take into account that
+        // the coordinate system for the selector is outside the slide so
+        // we have to correct the scale factor by `store.delta`
+        $('#selector').css({width: selector.width*scaleFactor*store.delta, height: selector.height*scaleFactor*store.delta});
+      
+        // Scale all the selected elements.
+        store.selectedItems.map(item => {
+          scaleItem(scaleFactor, scaleCenter, item);
+        });
+      }
+
+      
+
+    },
+    onend: event => {
+      scaleFactor = 0;
+
+      // TODO Actualizar la información del selector. Si se componen dos
+      // tipos de movimientos (p.e. un escalado y una rotación) no se realiza
+      // correctamente puesto que en el segundo movimiento se aplica la 
+      // información del selector inicial.
+
+      // AQUÍ SE GUARDAN LOS DATOS DE ESTA FORMA NORMALMENTE:
+      store.selectedItems.map(item => {
+        // Convertimos el item a un node de jQuery para mayor comodidad
+        const $item = $(item.node);
+        // Como el objeto se mueve a través del DOM y no del store
+        // La obtención final de los datos la obtenemos siempre de lo
+        // que tenemos en pantalla y nos dice el CSS
+        const posicionFinalXDelItem = parseFloat($item.css('left'));
+        const posicionFinalYDelItem = parseFloat($item.css('top'));
+        item.setPosition(posicionFinalXDelItem, posicionFinalYDelItem);
+        const anchoFinal = $item.width();
+        const altoFinal = $item.height();
+        // TODO: Al escalar un grupo da error la siguiente función.
+        item.setSize(anchoFinal, altoFinal);
+        const rotaciónFinal = getRotationDegrees($item);
+        item.setRotation(rotaciónFinal);
+      });
+    }
+  });
+};
+const destroyResize = () => {
+  interact('.pointers').unset();
+};
+
+export { attachResize, destroyResize };
 
       // console.group('Valores del selector con respecto a la ventana:');
       // console.log('x: ' + store.selector.node.style.left); 
@@ -229,71 +362,3 @@ const attachResize = () => {
       // // console.log('slide: ' + $slide);
       // console.log('delta' + store.delta);
       // console.groupEnd();
-    },
-    onmove: event => {
-      var userPull = new Point(event.dx, event.dy);
-      scaleDelta += userPull.component(scaleDirection) / store.delta;
-      scaleFactor = (selector.diagonal + scaleDelta) / selector.diagonal;
-
-      // We move the top-left vertex of the selector according with the 
-      // applied transformation
-      const selectorNewCenter = scale(scaleFactor, scaleCenter)(
-        new Point(selector.x + selector.width/2, selector.y + selector.height/2)
-      );
-      let selectorNewTopLeft = translate(new Point(-selector.width*scaleFactor/2, -selector.height*scaleFactor/2))(selectorNewCenter);
-      // We transform coordinates from slide to window
-      selectorNewTopLeft = changeCoordinatesFromSlideToWindow(slide, store.delta, selectorNewTopLeft);
-      // Position #selector in the window. It is not necessary to `rotate`
-      // again the element since the scale does not affect the rotation of
-      // the element.
-      $('#selector').css({ left: selectorNewTopLeft.x, top: selectorNewTopLeft.y });
-
-      // Finally we *scale* the selector. We have to take into account that
-      // the coordinate system for the selector is outside the slide so
-      // we have to correct the scale factor by `store.delta`
-      $('#selector').css({width: selector.width*scaleFactor*store.delta, height: selector.height*scaleFactor*store.delta});
-
-      
-      store.selectedItems.map(item => {
-        if (clickPoint === 'em' || clickPoint === 'nm' || clickPoint === 'wm' || clickPoint === 'sm'){
-          scaleDirItem(scaleFactor, scaleDirection, scaleCenter, item);
-        }
-        else{ 
-          scaleItem(scaleFactor, scaleCenter, item);
-        }
-      });
-
-    },
-    onend: event => {
-      scaleFactor = 0;
-
-      // TODO Actualizar la información del selector. Si se componen dos
-      // tipos de movimientos (p.e. un escalado y una rotación) no se realiza
-      // correctamente puesto que en el segundo movimiento se aplica la 
-      // información del selector inicial.
-
-      // AQUÍ SE GUARDAN LOS DATOS DE ESTA FORMA NORMALMENTE:
-      store.selectedItems.map(item => {
-        // Convertimos el item a un node de jQuery para mayor comodidad
-        const $item = $(item.node);
-        // Como el objeto se mueve a través del DOM y no del store
-        // La obtención final de los datos la obtenemos siempre de lo
-        // que tenemos en pantalla y nos dice el CSS
-        const posicionFinalXDelItem = parseFloat($item.css('left'));
-        const posicionFinalYDelItem = parseFloat($item.css('top'));
-        item.setPosition(posicionFinalXDelItem, posicionFinalYDelItem);
-        const anchoFinal = $item.width();
-        const altoFinal = $item.height();
-        // TODO: Al escalar un grupo da error la siguiente función.
-        item.setSize(anchoFinal, altoFinal);
-        const rotaciónFinal = getRotationDegrees($item);
-        item.setRotation(rotaciónFinal);
-      });
-    }
-  });
-};
-const destroyResize = () => {
-  interact('.pointers').unset();
-};
-
-export { attachResize, destroyResize };

--- a/src/Utils/ResizeItem.js
+++ b/src/Utils/ResizeItem.js
@@ -113,8 +113,8 @@ const attachResize = () => {
           break;
         case 'wm':
           scaleCenter = new Point(
-            selector.x, 
-            selector.y + selector.width/2
+            selector.x + selector.width, 
+            selector.y + selector.height/2
           );
           scaleDirection = new Point( -selector.width, 0);
           break;

--- a/src/Utils/ResizeItem.js
+++ b/src/Utils/ResizeItem.js
@@ -183,7 +183,6 @@ const attachResize = () => {
           new Point(-newWidth / 2, -newHeight / 2)
         )(selectorNewCenter);
 
-
         // We transform coordinates from slide to window
         selectorNewTopLeft = changeCoordinatesFromSlideToWindow(
           slide,
@@ -230,19 +229,8 @@ const attachResize = () => {
           )
         )(selectorNewCenter);
 
-        // We update the #fake-drag position and dimensions.
-        // It is exactly the same as the selector but before
-        // applying the coordinate change to the window.
-        if (store.selectedItems.length > 1) {
-          store.internaleDraggable.node.style.left = selectorNewTopLeft.x + 'px';
-          store.internaleDraggable.node.style.top = selectorNewTopLeft.y + 'px';
-          store.internaleDraggable.node.style.width = selector.width * scaleFactor + 'px';
-          store.internaleDraggable.node.style.height = selector.height * scaleFactor + 'px';
-        }
-
-
         // We transform coordinates from slide to window
-        selectorNewTopLeft = changeCoordinatesFromSlideToWindow(
+        let selectorNewTopLeftinWindowCoord = changeCoordinatesFromSlideToWindow(
           slide,
           store.delta,
           selectorNewTopLeft
@@ -251,8 +239,8 @@ const attachResize = () => {
         // again the element since the scale does not affect the rotation of
         // the element.
         $('#selector').css({
-          left: selectorNewTopLeft.x,
-          top: selectorNewTopLeft.y,
+          left: selectorNewTopLeftinWindowCoord.x,
+          top: selectorNewTopLeftinWindowCoord.y,
         });
 
         // Finally we *scale* the selector. We have to take into account that
@@ -267,6 +255,16 @@ const attachResize = () => {
         store.selectedItems.map(item => {
           scaleItem(scaleFactor, scaleCenter, item);
         });
+
+        // We update the #fake-drag position and dimensions.
+        // It is exactly the same as the selector but before
+        // applying the coordinate change to the window.
+        if (store.selectedItems.length > 1) {
+          store.internaleDraggable.node.style.left = selectorNewTopLeft.x + 'px';
+          store.internaleDraggable.node.style.top = selectorNewTopLeft.y + 'px';
+          store.internaleDraggable.node.style.width = selector.width * scaleFactor + 'px';
+          store.internaleDraggable.node.style.height = selector.height * scaleFactor + 'px';
+        }
       }
     },
     onend: event => {

--- a/src/Utils/ResizeItem.js
+++ b/src/Utils/ResizeItem.js
@@ -1,13 +1,15 @@
 import interact from 'interactjs';
 import store from '../Store';
 import $ from 'jquery';
-import { getRotationDegrees, changeCoordinatesFromWindowToSlide, changeCoordinatesFromSlideToWindow, scaleItem } from './Math';
-import {Point, rotate, translate, scale } from './planeTransforms.js';
+import { getRotationDegrees, changeCoordinatesFromWindowToSlide, changeCoordinatesFromSlideToWindow, scaleItem, scaleDirItem } from './Math';
+import {Point, rotate, translate, scale} from './planeTransforms.js';
 
 var selector;
 var slide;
 var scaleCenter = new Point(0,0);     // Center of the scale transformation
 var scaleFactor = 0;                  // Scale factor to apply
+
+var clickPoint = ''; // vertex of the selector clicked by the user
 
 // Direction of the mouse movement that will be consider to scale the element
 var scaleDirection = new Point(0,0);
@@ -46,13 +48,14 @@ const attachResize = () => {
       // - 'ne', 'nw', 'se', 'sw' Esquinas
       // console.log(event.currentTarget.getAttribute('id')); 
 
+      clickPoint = event.currentTarget.getAttribute('id');
       // Compute the center of the scale. It is the opposite point selected
-      // by the user. Observe that selector.x, selector.y) is the top left
+      // by the user. Observe that (selector.x, selector.y) is the top left
       // corner of the selector before selector.rotate (if any)
       // TODO: If p is the point with coordinates with respect to the slide 
       // of the point clicked by the user the following switch can be sustituted by
       // const scaleCenter = rotate(180, new Point(selector.x + selector.width/2, selector.y + selector.height/2))(p);
-      switch(event.currentTarget.getAttribute('id')){
+      switch(clickPoint){
         case 'nw':
           scaleCenter = new Point(
             selector.x + selector.width, 
@@ -97,7 +100,7 @@ const attachResize = () => {
         case 'sm':
           scaleCenter = new Point(
             selector.x + selector.width/2, 
-            selector.y + selector.height
+            selector.y
           );
           scaleDirection = new Point( 0, selector.height);
           break;
@@ -252,7 +255,12 @@ const attachResize = () => {
 
       
       store.selectedItems.map(item => {
-        scaleItem(scaleFactor, scaleCenter, item);
+        if (clickPoint === 'em' || clickPoint === 'nm' || clickPoint === 'wm' || clickPoint === 'sm'){
+          scaleDirItem(scaleFactor, scaleDirection, scaleCenter, item);
+        }
+        else{ 
+          scaleItem(scaleFactor, scaleCenter, item);
+        }
       });
 
     },

--- a/src/Utils/ResizeItem.js
+++ b/src/Utils/ResizeItem.js
@@ -1,21 +1,26 @@
 import interact from 'interactjs';
 import store from '../Store';
 import $ from 'jquery';
-import { getRotationDegrees, changeCoordinatesFromWindowToSlide, changeCoordinatesFromSlideToWindow, scaleItem, scaleDirItem } from './Math';
+import {
+  getRotationDegrees,
+  changeCoordinatesFromWindowToSlide,
+  changeCoordinatesFromSlideToWindow,
+  scaleItem,
+  scaleDirItem,
+} from './Math';
 import {Point, rotate, translate, scale, scaleDir} from './planeTransforms.js';
 
 var selector;
 var slide;
-var scaleCenter = new Point(0,0);     // Center of the scale transformation
-var scaleFactor = 0;                  // Scale factor to apply
+var scaleCenter = new Point(0, 0); // Center of the scale transformation
+var scaleFactor = 0; // Scale factor to apply
 
 var clickedPoint = ''; // vertex of the selector clicked by the user
 
 // Direction of the mouse movement that will be consider to scale the element
-var scaleDirection = new Point(0,0);
+var scaleDirection = new Point(0, 0);
 // Amount of mouse movement in the scaleDirection normalize by store.delta
 var scaleDelta = 0;
-
 
 const attachResize = () => {
   interact('.pointers').draggable({
@@ -24,28 +29,30 @@ const attachResize = () => {
 
       // Coordinates of selector with respect to browser window
       const selectorFromWindow = new Point(
-        parseFloat(store.selector.node.style.left), 
+        parseFloat(store.selector.node.style.left),
         parseFloat(store.selector.node.style.top)
       );
 
       // We compute the coordinates of the selector with respect to slide
       selector = changeCoordinatesFromWindowToSlide(
-        slide, 
-        store.delta, 
+        slide,
+        store.delta,
         selectorFromWindow
       );
 
       // We add to selector its width, height, angle and diagonal length
       // with respect to the slide (store.delta scaled)
-      selector.width = parseFloat(store.selector.node.style.width)/store.delta;
-      selector.height = parseFloat(store.selector.node.style.height)/store.delta;
+      selector.width =
+        parseFloat(store.selector.node.style.width) / store.delta;
+      selector.height =
+        parseFloat(store.selector.node.style.height) / store.delta;
       selector.rotate = getRotationDegrees($(store.selector.node));
       selector.diagonal = Math.hypot(selector.width, selector.height);
 
       // Reset the scaleDelta after a complete scaling
       scaleDelta = 0;
 
-      // id del tirador: 
+      // id del tirador:
       // - 'nm', 'wm', 'em', 'sm' Puntos medios
       // - 'ne', 'nw', 'se', 'sw' Esquinas
       clickedPoint = event.currentTarget.getAttribute('id');
@@ -53,81 +60,62 @@ const attachResize = () => {
       // Compute the center of the scale. It is the opposite point selected
       // by the user. Observe that (selector.x, selector.y) is the top left
       // corner of the selector before selector.rotate (if any)
-      // TODO: If p is the point with coordinates with respect to the slide 
+      // TODO: If p is the point with coordinates with respect to the slide
       // of the point clicked by the user the following switch can be sustituted by
       // const scaleCenter = rotate(180, new Point(selector.x + selector.width/2, selector.y + selector.height/2))(p);
-      switch(clickedPoint){
+      switch (clickedPoint) {
         case 'nw':
           scaleCenter = new Point(
-            selector.x + selector.width, 
+            selector.x + selector.width,
             selector.y + selector.height
           );
-          scaleDirection = new Point(
-            - selector.width,
-            - selector.height
-          );
+          scaleDirection = new Point(-selector.width, -selector.height);
           break;
         case 'nm':
           scaleCenter = new Point(
-            selector.x + selector.width/2, 
+            selector.x + selector.width / 2,
             selector.y + selector.height
           );
-          scaleDirection = new Point( 0, -selector.height);
+          scaleDirection = new Point(0, -selector.height);
           break;
         case 'ne':
-          scaleCenter = new Point(
-            selector.x, 
-            selector.y + selector.height
-          );
-          scaleDirection = new Point(
-            selector.width,
-            -selector.height
-          );
-          break; 
+          scaleCenter = new Point(selector.x, selector.y + selector.height);
+          scaleDirection = new Point(selector.width, -selector.height);
+          break;
         case 'em':
-          scaleCenter = new Point(
-            selector.x, 
-            selector.y + selector.width/2
-          );
-          scaleDirection = new Point( selector.width, 0 );
+          scaleCenter = new Point(selector.x, selector.y + selector.width / 2);
+          scaleDirection = new Point(selector.width, 0);
           break;
         case 'se':
           scaleCenter = new Point(selector.x, selector.y);
-          scaleDirection = new Point(
-            selector.width,
-            selector.height
-          );
+          scaleDirection = new Point(selector.width, selector.height);
           break;
         case 'sm':
-          scaleCenter = new Point(
-            selector.x + selector.width/2, 
-            selector.y
-          );
-          scaleDirection = new Point( 0, selector.height);
+          scaleCenter = new Point(selector.x + selector.width / 2, selector.y);
+          scaleDirection = new Point(0, selector.height);
           break;
         case 'sw':
-          scaleCenter = new Point(
-            selector.x + selector.width, 
-            selector.y
-          );
-          scaleDirection = new Point(
-            -selector.width,
-            selector.height
-          );
+          scaleCenter = new Point(selector.x + selector.width, selector.y);
+          scaleDirection = new Point(-selector.width, selector.height);
           break;
         case 'wm':
           scaleCenter = new Point(
-            selector.x + selector.width, 
-            selector.y + selector.height/2
+            selector.x + selector.width,
+            selector.y + selector.height / 2
           );
-          scaleDirection = new Point( -selector.width, 0);
+          scaleDirection = new Point(-selector.width, 0);
           break;
       }
-      // scaleCenter and scaleDirection are computed with respect to the 
-      // selector before applying an eventual rotation. We have to apply 
-      // to them the same rotation as the selector element to correctly 
+      // scaleCenter and scaleDirection are computed with respect to the
+      // selector before applying an eventual rotation. We have to apply
+      // to them the same rotation as the selector element to correctly
       // get its coordinates in the slide
-      scaleCenter = rotate(selector.rotate, new Point(selector.x + selector.width/2, selector.y + selector.height/2))(scaleCenter);
+      scaleCenter = rotate(
+        selector.rotate,
+        new Point(
+          selector.x + selector.width / 2,
+          selector.y + selector.height / 2)
+      )(scaleCenter);
       scaleDirection = rotate(selector.rotate)(scaleDirection);
     },
     onmove: event => {
@@ -136,106 +124,157 @@ const attachResize = () => {
 
       // TODO: The transformation applied to the `selector` is exactly the same
       // to the one applied to item. However, since `selector` and `item` do
-      // not have the same model (notice that SelectorModel and ItemModel 
+      // not have the same model (notice that SelectorModel and ItemModel
       // represents the top-left vertex by (x,y) and (left, right) respectively)
-      // we cannot use the `scaleItem` function to update the selector 
+      // we cannot use the `scaleItem` function to update the selector
       // position, width and height. As a consequence, we have to repeat
-      // the same inner code of `scaleItem` or `scaleDirItem` to update selector. 
-      // Moreover, selector coordinates are computed with respect to the window 
-      // and a change of coordinate is needed to correctly position it 
+      // the same inner code of `scaleItem` or `scaleDirItem` to update selector.
+      // Moreover, selector coordinates are computed with respect to the window
+      // and a change of coordinate is needed to correctly position it
       // in the slide.
 
-      // Apply the non-proportional scale if the `clickedPoint` is in the 
+      // Apply the non-proportional scale if the `clickedPoint` is in the
       // midpoint of one of the selector sides.
-      if (clickedPoint === 'em' || clickedPoint === 'nm' || clickedPoint === 'wm' || clickedPoint === 'sm'){
-        if (clickedPoint === 'em' || clickedPoint === 'wm'){
+      if (
+        clickedPoint === 'em' ||
+        clickedPoint === 'nm' ||
+        clickedPoint === 'wm' ||
+        clickedPoint === 'sm'
+      ) {
+        if (clickedPoint === 'em' || clickedPoint === 'wm') {
           scaleFactor = (selector.width + scaleDelta) / selector.width;
-        }
-        else {
+        } else {
           scaleFactor = (selector.height + scaleDelta) / selector.height;
         }
 
         // Update selector position
-        const selectorCenter = new Point( selector.x + selector.width / 2, selector.y + selector.height / 2 );
+        const selectorCenter = new Point(
+          selector.x + selector.width / 2,
+          selector.y + selector.height / 2
+        );
         const selectorTopLeft = rotate(selector.rotate, selectorCenter)(
           selector
         );
         const selectorTopRight = rotate(selector.rotate, selectorCenter)(
-          new Point( selector.x + selector.width, selector.y )
+          new Point(selector.x + selector.width, selector.y)
         );
         const selectorBottomLeft = rotate(selector.rotate, selectorCenter)(
-          new Point( selector.x, selector.y + selector.height )
+          new Point(selector.x, selector.y + selector.height)
         );
 
         // The angle of the selector has not changed since scale preserves angles
         // The new center of selector is the *transformed* center by the scale
-        const selectorNewCenter = scaleDir(scaleFactor, scaleDirection, scaleCenter)(selectorCenter);
+        const selectorNewCenter = scaleDir(
+          scaleFactor,
+          scaleDirection,
+          scaleCenter
+        )(selectorCenter);
         const newWidth = Point.distance(
           scaleDir(scaleFactor, scaleDirection, scaleCenter)(selectorTopLeft),
           scaleDir(scaleFactor, scaleDirection, scaleCenter)(selectorTopRight)
         );
         const newHeight = Point.distance(
           scaleDir(scaleFactor, scaleDirection, scaleCenter)(selectorTopLeft),
-          scaleDir(scaleFactor, scaleDirection, scaleCenter)(selectorBottomLeft)
+          scaleDir(scaleFactor, scaleDirection, scaleCenter)(
+            selectorBottomLeft
+          )
         );
-        let selectorNewTopLeft = translate(new Point(-newWidth/2, -newHeight/2))(selectorNewCenter);
+        let selectorNewTopLeft = translate(
+          new Point(-newWidth / 2, -newHeight / 2)
+        )(selectorNewCenter);
+
 
         // We transform coordinates from slide to window
-        selectorNewTopLeft = changeCoordinatesFromSlideToWindow(slide, store.delta, selectorNewTopLeft);
+        selectorNewTopLeft = changeCoordinatesFromSlideToWindow(
+          slide,
+          store.delta,
+          selectorNewTopLeft
+        );
         // Position #selector in the window. It is not necessary to `rotate`
         // again the element since the scale does not affect the rotation of
         // the element.
-        $('#selector').css({ left: selectorNewTopLeft.x, top: selectorNewTopLeft.y });
+        $('#selector').css({
+          left: selectorNewTopLeft.x,
+          top: selectorNewTopLeft.y,
+        });
 
         // Finally we *scale* the selector. We have to take into account that
         // the coordinate system for the selector is outside the slide so
         // we have to correct the scale factor by `store.delta`
-        $('#selector').css({width: newWidth*store.delta, height: newHeight*store.delta});
+        $('#selector').css({
+          width: newWidth * store.delta,
+          height: newHeight * store.delta,
+        });
 
         // Scale all the selected elements.
         store.selectedItems.map(item => {
           scaleDirItem(scaleFactor, scaleDirection, scaleCenter, item);
         });
-
-      }
-      else{ // Apply the proportional scale
+      } else {
+        // Apply the proportional scale
         scaleFactor = (selector.diagonal + scaleDelta) / selector.diagonal;
 
         // Update selector position
-        // We move the top-left vertex of the selector according with the 
+        // We move the top-left vertex of the selector according with the
         // applied transformation
         const selectorNewCenter = scale(scaleFactor, scaleCenter)(
-          new Point(selector.x + selector.width/2, selector.y + selector.height/2)
+          new Point(
+            selector.x + selector.width / 2,
+            selector.y + selector.height / 2
+          )
         );
-        let selectorNewTopLeft = translate(new Point(-selector.width*scaleFactor/2, -selector.height*scaleFactor/2))(selectorNewCenter);
+        let selectorNewTopLeft = translate(
+          new Point(
+            -selector.width * scaleFactor / 2,
+            -selector.height * scaleFactor / 2
+          )
+        )(selectorNewCenter);
+
+        // We update the #fake-drag position and dimensions.
+        // It is exactly the same as the selector but before
+        // applying the coordinate change to the window.
+        if (store.selectedItems.length > 1) {
+          store.internaleDraggable.node.style.left = selectorNewTopLeft.x + 'px';
+          store.internaleDraggable.node.style.top = selectorNewTopLeft.y + 'px';
+          store.internaleDraggable.node.style.width = selector.width * scaleFactor + 'px';
+          store.internaleDraggable.node.style.height = selector.height * scaleFactor + 'px';
+        }
+
 
         // We transform coordinates from slide to window
-        selectorNewTopLeft = changeCoordinatesFromSlideToWindow(slide, store.delta, selectorNewTopLeft);
+        selectorNewTopLeft = changeCoordinatesFromSlideToWindow(
+          slide,
+          store.delta,
+          selectorNewTopLeft
+        );
         // Position #selector in the window. It is not necessary to `rotate`
         // again the element since the scale does not affect the rotation of
         // the element.
-        $('#selector').css({ left: selectorNewTopLeft.x, top: selectorNewTopLeft.y });
+        $('#selector').css({
+          left: selectorNewTopLeft.x,
+          top: selectorNewTopLeft.y,
+        });
 
         // Finally we *scale* the selector. We have to take into account that
         // the coordinate system for the selector is outside the slide so
         // we have to correct the scale factor by `store.delta`
-        $('#selector').css({width: selector.width*scaleFactor*store.delta, height: selector.height*scaleFactor*store.delta});
-      
+        $('#selector').css({
+          width: selector.width * scaleFactor * store.delta,
+          height: selector.height * scaleFactor * store.delta,
+        });
+
         // Scale all the selected elements.
         store.selectedItems.map(item => {
           scaleItem(scaleFactor, scaleCenter, item);
         });
       }
-
-      
-
     },
     onend: event => {
       scaleFactor = 0;
 
       // TODO Actualizar la información del selector. Si se componen dos
       // tipos de movimientos (p.e. un escalado y una rotación) no se realiza
-      // correctamente puesto que en el segundo movimiento se aplica la 
+      // correctamente puesto que en el segundo movimiento se aplica la
       // información del selector inicial.
 
       // AQUÍ SE GUARDAN LOS DATOS DE ESTA FORMA NORMALMENTE:
@@ -255,110 +294,109 @@ const attachResize = () => {
         const rotaciónFinal = getRotationDegrees($item);
         item.setRotation(rotaciónFinal);
       });
-    }
+    },
   });
 };
 const destroyResize = () => {
   interact('.pointers').unset();
 };
 
-export { attachResize, destroyResize };
+export {attachResize, destroyResize};
 
-      // console.group('Valores del selector con respecto a la ventana:');
-      // console.log('x: ' + store.selector.node.style.left); 
-      // console.log('y: ' + store.selector.node.style.top);
-      // console.log('w: ' + store.selector.node.style.width);
-      // console.log('h: ' + store.selector.node.style.height);
-      // console.groupEnd();
+// console.group('Valores del selector con respecto a la ventana:');
+// console.log('x: ' + store.selector.node.style.left);
+// console.log('y: ' + store.selector.node.style.top);
+// console.log('w: ' + store.selector.node.style.width);
+// console.log('h: ' + store.selector.node.style.height);
+// console.groupEnd();
 
-      // console.group('Valores del selector con respecto al slide:');
-      // const newTopLeft = changeCoordinatesFromWindowToSlide(
-      //   new Point(slide.x, slide.y), 
-      //   store.delta, 
-      //   new Point(
-      //     parseFloat(store.selector.node.style.left), parseFloat(store.selector.node.style.top))
-      // );
-      // console.log('x: ' + newTopLeft.x); 
-      // console.log('y: ' + newTopLeft.y);
-      // console.log('w: ' + store.selector.node.style.width/store.delta);
-      // console.log('h: ' + store.selector.node.style.height/store.delta);
-      // console.groupEnd();
+// console.group('Valores del selector con respecto al slide:');
+// const newTopLeft = changeCoordinatesFromWindowToSlide(
+//   new Point(slide.x, slide.y),
+//   store.delta,
+//   new Point(
+//     parseFloat(store.selector.node.style.left), parseFloat(store.selector.node.style.top))
+// );
+// console.log('x: ' + newTopLeft.x);
+// console.log('y: ' + newTopLeft.y);
+// console.log('w: ' + store.selector.node.style.width/store.delta);
+// console.log('h: ' + store.selector.node.style.height/store.delta);
+// console.groupEnd();
 
+// // items seleccionados
+// store.selectedItems.map(item => {
+//   console.group('Valores del item con color:' + item.background);
 
-      // // items seleccionados
-      // store.selectedItems.map(item => {
-      //   console.group('Valores del item con color:' + item.background);
+//   console.log('Valores del item en el store: ');
+//   console.log('x: ' + item.left);
+//   console.log('y: ' + item.top);
+//   console.log('w: ' + item.width);
+//   console.log('h: ' + item.height);
+//   console.log('r: ' + item.rotate);
 
-      //   console.log('Valores del item en el store: ');
-      //   console.log('x: ' + item.left);
-      //   console.log('y: ' + item.top);
-      //   console.log('w: ' + item.width);
-      //   console.log('h: ' + item.height);
-      //   console.log('r: ' + item.rotate);
+//   console.groupEnd();
+// });
 
-      //   console.groupEnd();
-      // });
+// Datos importantes del event
 
-      // Datos importantes del event
+// Tirador (bolita desde donde se tira)
+// console.group('Datos del evento: ');
+// console.log('Evento currentTarget: ');
+// console.log(event.currentTarget);
+// console.log('Id para saber el tirador currentTarget: ');
+// // id del tirador:
+// // - 'nm', 'wm', 'em', 'sm' Puntos medios
+// // - 'ne', 'nw', 'se', 'sw' Esquinas
+// console.log(event.currentTarget.getAttribute('id')); // id del tirador, para saber cual es
+// console.groupEnd();
 
-      // Tirador (bolita desde donde se tira)
-      // console.group('Datos del evento: ');
-      // console.log('Evento currentTarget: ');
-      // console.log(event.currentTarget);
-      // console.log('Id para saber el tirador currentTarget: ');
-      // // id del tirador: 
-      // // - 'nm', 'wm', 'em', 'sm' Puntos medios
-      // // - 'ne', 'nw', 'se', 'sw' Esquinas
-      // console.log(event.currentTarget.getAttribute('id')); // id del tirador, para saber cual es
-      // console.groupEnd();
+// console.group('Datos del Selector: ');
+// // Obtener posiciones del selector con respecto a la ventana
+// console.log('Datos con respecto a la ventana del selector: ');
+// console.log(store.selector.node.getBoundingClientRect); // posiciones
+// console.log(store.selector.node); // posiciones
+// console.log(store.selector.node.style.left); // posiciones
+// // Convertimos a jQuery para obtener la rotación, esto se puede hacer de varias formas:
+// const $selectorConJquery = $(store.selector.node);
+// console.log(
+//   'Rotación del selector: ' + getRotationDegrees($selectorConJquery)
+// ); // el valor es cero cuando está el tirador del rotador abajo
+// console.groupEnd();
 
-      // console.group('Datos del Selector: ');
-      // // Obtener posiciones del selector con respecto a la ventana
-      // console.log('Datos con respecto a la ventana del selector: ');
-      // console.log(store.selector.node.getBoundingClientRect); // posiciones
-      // console.log(store.selector.node); // posiciones
-      // console.log(store.selector.node.style.left); // posiciones
-      // // Convertimos a jQuery para obtener la rotación, esto se puede hacer de varias formas:
-      // const $selectorConJquery = $(store.selector.node);
-      // console.log(
-      //   'Rotación del selector: ' + getRotationDegrees($selectorConJquery)
-      // ); // el valor es cero cuando está el tirador del rotador abajo
-      // console.groupEnd();
+// console.group('Valores de los items seleccionados: ');
+// // Obtener datos de los elementos seleccionados
+// store.selectedItems.map(item => {
+//   console.group('Valores del item con color:' + item.background);
+//   console.log('Nodo HTML: ');
+//   console.log(item.node); // Objeto nativo de javascript, equivale a document.getElementById
+//   console.log('Valores con respecto a la ventana:');
+//   console.log(item.node.getBoundingClientRect()); // Valores con respecto a la ventana
+//   console.log('Valores con respecto al slide:');
+//   const $item = $(item.node);
+//   console.log('x: ' + parseFloat($item.css('left')));
+//   console.log('y: ' + parseFloat($item.css('top')));
+//   console.log('w: ' + $item.width());
+//   console.log('h: ' + $item.height());
+//   console.log('Rotación del item: ' + getRotationDegrees($item));
 
-      // console.group('Valores de los items seleccionados: ');
-      // // Obtener datos de los elementos seleccionados
-      // store.selectedItems.map(item => {
-      //   console.group('Valores del item con color:' + item.background);
-      //   console.log('Nodo HTML: ');
-      //   console.log(item.node); // Objeto nativo de javascript, equivale a document.getElementById
-      //   console.log('Valores con respecto a la ventana:');
-      //   console.log(item.node.getBoundingClientRect()); // Valores con respecto a la ventana
-      //   console.log('Valores con respecto al slide:');
-      //   const $item = $(item.node);
-      //   console.log('x: ' + parseFloat($item.css('left')));
-      //   console.log('y: ' + parseFloat($item.css('top')));
-      //   console.log('w: ' + $item.width());
-      //   console.log('h: ' + $item.height());
-      //   console.log('Rotación del item: ' + getRotationDegrees($item));
+//   console.log('Valores del item en el store: ');
+//   console.log('x: ' + item.left);
+//   console.log('y: ' + item.top);
+//   console.log('w: ' + item.width);
+//   console.log('h: ' + item.height);
+//   console.log('r: ' + item.rotate);
 
-      //   console.log('Valores del item en el store: ');
-      //   console.log('x: ' + item.left);
-      //   console.log('y: ' + item.top);
-      //   console.log('w: ' + item.width);
-      //   console.log('h: ' + item.height);
-      //   console.log('r: ' + item.rotate);
+//   console.groupEnd();
+// });
+// console.groupEnd();
 
-      //   console.groupEnd();
-      // });
-      // console.groupEnd();
-
-      // console.group('Datos de la slide: ');
-      // console.log('Datos con respecto a la ventana: ');
-      // console.log(document.getElementById('slide').getBoundingClientRect());
-      // console.log('Datos de ancho y alto: ');
-      // const $slide = $(document.getElementById('slide'));
-      // console.log('w: ' + $slide.width());
-      // console.log('h: ' + $slide.height());
-      // // console.log('slide: ' + $slide);
-      // console.log('delta' + store.delta);
-      // console.groupEnd();
+// console.group('Datos de la slide: ');
+// console.log('Datos con respecto a la ventana: ');
+// console.log(document.getElementById('slide').getBoundingClientRect());
+// console.log('Datos de ancho y alto: ');
+// const $slide = $(document.getElementById('slide'));
+// console.log('w: ' + $slide.width());
+// console.log('h: ' + $slide.height());
+// // console.log('slide: ' + $slide);
+// console.log('delta' + store.delta);
+// console.groupEnd();

--- a/src/Utils/RotateItem.js
+++ b/src/Utils/RotateItem.js
@@ -42,6 +42,8 @@ interact('.pointer9').draggable({
     };
 
     if (store.selectedItems.length > 1) {
+      // TODO (Recomendación) El centro de rotación debería siempre 
+      // calcularse usando la información del selector.
       const $fakeDrag = $('#fake-drag');
       centroDeRotacionReal = {
         x: parseFloat($fakeDrag.css('left')) + $fakeDrag.width() / 2,

--- a/src/Utils/planeTransforms.js
+++ b/src/Utils/planeTransforms.js
@@ -165,21 +165,6 @@ const rotateOrigin = function(angle) {
   };
 };
 
-/*
- * Scale with respect to a given direction v = (v.x, v.y). Returns a 
- * (generally non-proportional) scale of center the origin and *ratio* 
- * v.x in the X-direction and v.y in the Y-direction
- *
- * @param {Point} v - Vector that defined the scale.
- *
- * @return {Function} scale acording to the direction of v.
- */
-const scaleDirOrigin = function(v){
-  return function(p){
-    return new Point(v.x * p.x, v.y * p.y);
-  };
-};
-
 /* 
  * Scale with respect to the origin constructor. Returns a (proportional) 
  * scale of center the origin and *ratio* `scaleFactor`.
@@ -194,12 +179,28 @@ const scaleDirOrigin = function(v){
  * center the origin.
  */
 const scaleOrigin = function(scaleFactor) {
-  // Equivalent to this.scaleDirOrigin(scaleFactor, scaleFactor)
   return function(p) {
     return new Point(scaleFactor * p.x, scaleFactor * p.y);
   };
 };
 
+/*
+ * Non-proportional scale only in a given direction v = (v.x, v.y) by
+ * a scale factor. 
+ *
+ * @param {Number} scaleFactor - scale factor to apply. 
+ * @param {Point} v - Vector that defined the direction the scale is applied.
+ *
+ * @return {Function} scale in the v direction by scaleFactor.
+ */
+const scaleDirOrigin = function(scaleFactor, v){
+  return function(p){
+    p = rotateOrigin(-v.angle)(p);
+    let q = new Point(scaleFactor*p.x, p.y);
+    q = rotateOrigin(v.angle)(q);
+    return q;
+  };
+};
 
 /* 
  * Scale in the X direction constructor. Returns a (non-proportional) scale 
@@ -216,7 +217,7 @@ const scaleOrigin = function(scaleFactor) {
  * of X axis of ratio scaleFactor and center the origin.
  */
 const scaleXOrigin = function(scaleFactor) {
-  // Equivalent to this.scaleDirOrigin(scaleFactor, 0)
+  // Equivalent to this.scaleDirOrigin(scaleFactor, {x:1, y:0})
   return function(p) {
     return new Point(scaleFactor * p.x, p.y);
   };
@@ -237,7 +238,7 @@ const scaleXOrigin = function(scaleFactor) {
  * of Y axis of ratio scaleFactor and center the origin.
  */
 const scaleYOrigin = function(scaleFactor) {
-  // Equivalent to this.scaleDirOrigin(0, scaleFactor)
+  // Equivalent to this.scaleDirOrigin(scaleFactor, {x:0, y:1})
   return function(p) {
     return new Point(p.x, scaleFactor * p.y);
   };
@@ -316,23 +317,19 @@ const scale = function(scaleFactor, center = new Point(0, 0)) {
 };
 
 /*
- * Scale in the direction of a vector v = (v.x, v.y) with respect to a 
- * given point constructor.
- * Returns a (generally non-proportional) scale of center a given point 
- * `center` and scale factor v.x in the X-direction and v.y in the Y-direction
+ * Non-proportional scale only in a given direction v by a scale factor. 
+ * Returns a non-proportional scale of center a given point 
+ * `center` and ´scaleFactor` only in the direction given by v. 
  *
+ * @param {Number} scaleFactor - scale factor of the transformation
  * @param {Point} v - Vector that defined the scale.
  * @param {Point} center - center of scaling.
  *
- * @return {Function} scale in the direction of `v` with respect to `center`
+ * @return {Function} scale by `scaleFactor` in the direction of `v` with 
+ * respect to `center`
  */
-const scaleDir = function(v, center = new Point(0, 0)){
-  const dirAngle = center.angle;
-  return function(p){
-    let q = rotate(-dirAngle, center)(p);
-    let scaleQ = moveTransformOrigin(scaleDirOrigin(v), center)(q);
-    return rotate(dirAngle, center)(scaleQ);
-  };
+const scaleDir = function(scaleFactor, v, center = new Point(0, 0)){
+  return moveTransformOrigin(scaleDirOrigin(scaleFactor, v), center);
 };
 
 /*

--- a/src/index.css
+++ b/src/index.css
@@ -244,3 +244,10 @@ html.wm-cursor {
   background-color: black;
   opacity: 0.1;
 }
+
+.group{
+  background-color:black;
+  opacity:0.9;
+}
+
+


### PR DESCRIPTION
Esta es la primera versión completamente funcional del escalado (proporcional o no) para una caja, selección de cajas o grupo de cajas.

El código necesita ser revisado (multitud de comentarios que ya no son relevantes) y comentado debidamente.

El código puede simplificarse si se unifican las notaciones para `SelectorModel` e `ItemModel` (en el primero se usa la notación `(x, y)` para el vértice mientras que en el segundo se usa `(left, top)`).  Ver TODO en `onmove`, archivo `ResizeItem.js`.